### PR TITLE
MediaView: change PanelDelegate provider from singleton to factory

### DIFF
--- a/Showcases/media_view/app/src/main/java/com/meta/levinriegner/mediaview/app/di/PresentationModule.kt
+++ b/Showcases/media_view/app/src/main/java/com/meta/levinriegner/mediaview/app/di/PresentationModule.kt
@@ -19,7 +19,6 @@ import javax.inject.Singleton
 @InstallIn(SingletonComponent::class)
 object PresentationModule {
 
-  @Singleton
   @Provides
   fun providePanelDelegate(): PanelDelegate {
     return SpatialActivityManager.getAppSystemActivity() as PanelDelegate


### PR DESCRIPTION
This change aims to resolve the `No panel creator found for key XX` crash.