### PR TITLE
Fix Spatial Audio for Spatial Video Sample by adding audio renderer to rendererList

### DIFF
--- a/SpatialVideoSample/app/src/main/java/com/meta/spatial/samples/spatialvideosample/SpatialVideoSampleActivity.kt
+++ b/SpatialVideoSample/app/src/main/java/com/meta/spatial/samples/spatialvideosample/SpatialVideoSampleActivity.kt
@@ -816,6 +816,7 @@ class CustomRenderersFactory : DefaultRenderersFactory {
             audioRendererEventListener,
             audioSink_,
         )
+    rendererList.add(0, audioRenderer)
     return rendererList.toTypedArray()
   }
 }


### PR DESCRIPTION
Summary: Spatial Audio was broken in the Spatial Video Sample. This change fixes it by adding the audio renderer to the rendererlist

Reviewed By: dav-s

Differential Revision: D72825867


