### PR TITLE
media view: use sdk version 0.6.0 from central repo, version bump

### DIFF
--- a/Showcases/media_view/app/build.gradle.kts
+++ b/Showcases/media_view/app/build.gradle.kts
@@ -42,8 +42,8 @@ android {
     minSdk = 29
     //noinspection ExpiredTargetSdkVersion
     targetSdk = 32
-    versionCode = 19
-    versionName = "0.0.17"
+    versionCode = 20
+    versionName = "0.0.18"
 
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     vectorDrawables { useSupportLibrary = true }

--- a/Showcases/media_view/app/src/main/java/com/meta/levinriegner/mediaview/app/di/PresentationModule.kt
+++ b/Showcases/media_view/app/src/main/java/com/meta/levinriegner/mediaview/app/di/PresentationModule.kt
@@ -19,6 +19,7 @@ import javax.inject.Singleton
 @InstallIn(SingletonComponent::class)
 object PresentationModule {
 
+  @Singleton
   @Provides
   fun providePanelDelegate(): PanelDelegate {
     return SpatialActivityManager.getAppSystemActivity() as PanelDelegate

--- a/Showcases/media_view/app/src/main/java/com/meta/levinriegner/mediaview/app/di/PresentationModule.kt
+++ b/Showcases/media_view/app/src/main/java/com/meta/levinriegner/mediaview/app/di/PresentationModule.kt
@@ -18,8 +18,7 @@ import javax.inject.Singleton
 @Module
 @InstallIn(SingletonComponent::class)
 object PresentationModule {
-
-  @Singleton
+  
   @Provides
   fun providePanelDelegate(): PanelDelegate {
     return SpatialActivityManager.getAppSystemActivity() as PanelDelegate

--- a/Showcases/media_view/app/src/main/java/com/meta/levinriegner/mediaview/app/immersive/ImmersiveActivity.kt
+++ b/Showcases/media_view/app/src/main/java/com/meta/levinriegner/mediaview/app/immersive/ImmersiveActivity.kt
@@ -49,9 +49,9 @@ class ImmersiveActivity : ComponentAppSystemActivity(), PanelDelegate {
 
   override fun registerFeatures(): List<SpatialFeature> {
     val features = mutableListOf<SpatialFeature>(VRFeature(this))
-    if (BuildConfig.DEBUG) {
-      features.add(CastInputForwardFeature(this))
-    }
+    //if (BuildConfig.DEBUG) {
+    //  features.add(CastInputForwardFeature(this))
+    //}
     return features
   }
 

--- a/Showcases/media_view/gradle.properties
+++ b/Showcases/media_view/gradle.properties
@@ -26,4 +26,4 @@ kotlin.code.style=official
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
 # Common version for Meta Spatial SDK across the project
-metaSpatialSdkVersion=0.5.5
+metaSpatialSdkVersion=0.6.0


### PR DESCRIPTION
 - Use Meta Spatial SDK version 0.6.0
 - Version bump to match version to be submitted to store