### PR TITLE
Geo Voyage Spatial SDK version upgrade

### DIFF
--- a/Showcases/geo_voyage/app/build.gradle.kts
+++ b/Showcases/geo_voyage/app/build.gradle.kts
@@ -22,7 +22,7 @@ android {
     minSdk = 29
     //noinspection ExpiredTargetSdkVersion
     targetSdk = 32
-    versionCode = 21
+    versionCode = 22
     versionName = "1.0.1"
 
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
@@ -80,7 +80,6 @@ dependencies {
 
   // Meta Spatial SDK libs
   implementation("com.meta.spatial:meta-spatial-sdk:$metaSpatialSdkVersion")
-  implementation("com.meta.spatial:meta-spatial-sdk-ovrmetrics:$metaSpatialSdkVersion")
   implementation("com.meta.spatial:meta-spatial-sdk-toolkit:$metaSpatialSdkVersion")
   implementation("com.meta.spatial:meta-spatial-sdk-vr:$metaSpatialSdkVersion")
 

--- a/Showcases/geo_voyage/gradle.properties
+++ b/Showcases/geo_voyage/gradle.properties
@@ -22,4 +22,4 @@ kotlin.code.style=official
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
 # Common version for Meta Spatial SDK across the project
-metaSpatialSdkVersion=0.6.0
+metaSpatialSdkVersion=0.6.1


### PR DESCRIPTION
- Updates the Meta Spatial SDK version to 0.6.1.
- Updates the app's version code.
- Removes an unused OVR metrics dependency.
