### PR TITLE
fix: increase ButtonsLayout panel height to prevent text cutoff

### DIFF
--- a/Showcases/UISetSample/app/src/main/java/com/meta/levinriegner/uiset/app/panel/PanelRegistry.kt
+++ b/Showcases/UISetSample/app/src/main/java/com/meta/levinriegner/uiset/app/panel/PanelRegistry.kt
@@ -40,7 +40,7 @@ class PanelRegistry {
         panelRegistration(
             PanelRegistrationIds.PANEL_BUTTONS_LAYOUT,
             layoutWidth = 1136f,
-            layoutHeight = 568f,
+            layoutHeight = 569f,
         ) {
           ButtonsLayout()
         },


### PR DESCRIPTION
Fix to bug reported: "On the Buttons Component panel, the description for Destructive buttons is partially cut off on the last line"